### PR TITLE
feat: credentialsupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,15 @@ Decodes both uncompressed and gzip compressed messages.
 async decode(message: Buffer, consumerschema: avro.Type): Promise<T>
 ````
 
+### Update the Glue client
+
+You can refresh the internally cached Glue client by calling `updateGlueClient`.
+This is particulary useful when credentials need to get updated.
+
+```typescript
+updateGlueClient(props?: sdk.Glue.ClientConfiguration)
+````
+
 ## Examples
 
 ### Nodejs Lambda function consuming a MSK/Kafka stream

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,14 +30,29 @@ export interface EncodeProps {
 }
 export declare class GlueSchemaRegistry<T> {
     private gc;
-    registryName: string;
+    readonly registryName: string;
     private glueSchemaIdCache;
     private avroSchemaCache;
+    /**
+     * Constructs a GlueSchemaRegistry
+     *
+     * @param registryName - name of the Glue registry you want to use
+     * @param props - optional AWS properties that are used when constructing the Glue object from the AWS SDK
+     */
     constructor(registryName: string, props?: sdk.Glue.ClientConfiguration);
+    /**
+     * Updates the Glue client. Useful if you need to update the credentials, for example.
+     *
+     * @param props settings for the AWS Glue client
+     */
+    updateGlueClient(props?: sdk.Glue.ClientConfiguration): void;
     private loadGlueSchema;
     /**
-     * Registers a new schema in the AWS Glue Schema Registry.
-     * Note: use the method register instead if you just want to register a new version of an existing schema.
+     * Creates a new schema in the AWS Glue Schema Registry.
+     * Note: do not use createSchema if you want to create a new version of an existing schema.
+     * Instead use register().
+     *
+     * @param props - the details about the schema
      * @throws if the schema already exists
      */
     createSchema(props: CreateSchemaProps): Promise<string | undefined>;
@@ -45,7 +60,9 @@ export declare class GlueSchemaRegistry<T> {
      * Registers a new version of an existing schema.
      * Returns the id of the existing schema version if a similar version already exists.
      * Throws an exception if the schema does not exist.
+     * Throws an exception if the Glue compatibility check fails.
      *
+     * @param props - the details about the schema
      * @returns {string} the id of the schema version.
      */
     register(props: RegisterSchemaProps): Promise<string>;
@@ -56,11 +73,20 @@ export declare class GlueSchemaRegistry<T> {
     private static COMPRESSION_DEFAULT_BYTE;
     private static COMPRESSION_ZLIB_BYTE;
     /**
-     * Encode the object with the glue schema with the given id
+     * Encode the object with a specific glue schema version
+     *
+     * @param glueSchemaId - UUID of the Glue schema version that should be used to encode the message
+     * @param object - the object to encode
+     * @param props - optional encoding options
+     * @returns - a Buffer containing the binary message
      */
     encode(glueSchemaId: string, object: T, props?: EncodeProps): Promise<Buffer>;
     /**
      * Decode a message with a specific schema.
+     *
+     * @param message - Buffer with the binary encoded message
+     * @param consumerschema - The Avro schema that should be used to decode the message
+     * @returns - the deserialized message as object
      */
     decode(message: Buffer, consumerschema: avro.Type): Promise<T>;
     private getAvroSchemaForGlueId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export class GlueSchemaRegistry<T> {
   https://github.com/awslabs/aws-glue-schema-registry/blob/master/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
   */
   private gc: sdk.Glue
-  registryName: string
+  public readonly registryName: string
   private glueSchemaIdCache: {
     [hash: string]: string
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,15 @@ export class GlueSchemaRegistry<T> {
     this.avroSchemaCache = {}
   }
 
+  /**
+   * Updates the Glue client. Useful if you need to update the credentials, for example.
+   *
+   * @param props settings for the AWS Glue client
+   */
+  public updateGlueClient(props?: sdk.Glue.ClientConfiguration) {
+    this.gc = new sdk.Glue(props)
+  }
+
   private async loadGlueSchema(schemaId: string) {
     const existingschema = await this.gc
       .getSchemaVersion({


### PR DESCRIPTION
This feature makes it possible to recreate the Glue client without having to recreate the GlueSchemaRegistry instance.
This makes it possible to update AWS credentials while keeping the schema cache.