### PR TITLE
feat: support getting wire protocol values separately

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -355,7 +355,7 @@ export class GlueSchemaRegistry<T> {
     return consumerschema.fromBuffer(await handlecompression(content), resolver)
   }
 
-  async getAvroSchemaForGlueId(id: string) {
+  async getAvroSchemaForGlueId(id: string): Promise<avro.Type> {
     if (this.avroSchemaCache[id]) return this.avroSchemaCache[id]
     const schemastring = (await this.loadGlueSchema(id)).SchemaDefinition
     if (!schemastring) throw new Error('Glue returned undefined schema definition')

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,7 +355,7 @@ export class GlueSchemaRegistry<T> {
     return consumerschema.fromBuffer(await handlecompression(content), resolver)
   }
 
-  private async getAvroSchemaForGlueId(id: string) {
+  async getAvroSchemaForGlueId(id: string) {
     if (this.avroSchemaCache[id]) return this.avroSchemaCache[id]
     const schemastring = (await this.loadGlueSchema(id)).SchemaDefinition
     if (!schemastring) throw new Error('Glue returned undefined schema definition')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -324,6 +324,32 @@ describe('test analyze message', () => {
   })
 })
 
+describe('test get wire protocol values', () => {
+  const schemaregistry = new GlueSchemaRegistry<TestTypeV2>('testregistry', {
+    region: 'eu-central-1',
+  })
+  test('should return values and no errors for a valid message', () => {
+    const result = schemaregistry.getWireProtocolValues(Buffer.from(compressedHelloWorld, 'hex'))
+    expect(result).toStrictEqual({
+      compression: GlueSchemaRegistry.COMPRESSION_ZLIB,
+      schemaId: 'b7912285-527d-42de-88ee-e389a763225f',
+      headerversion: GlueSchemaRegistry.HEADER_VERSION,
+    })
+  })
+  test('should return error for invalid header version', () => {
+    const result = schemaregistry.getWireProtocolValues(Buffer.from(malformedMessage, 'hex'))
+    expect(result).toStrictEqual({
+      error: ERROR.INVALID_HEADER_VERSION,
+    })
+  })
+  test('should return error for an invalid compression type', async () => {
+    const result = schemaregistry.getWireProtocolValues(Buffer.from(malformedCompression, 'hex'))
+    expect(result).toStrictEqual({
+      error: ERROR.INVALID_COMPRESSION,
+    })
+  })
+})
+
 describe('test error cases', () => {
   let schemaregistry: GlueSchemaRegistry<TestType>
   beforeAll(async () => {


### PR DESCRIPTION
Allow getting Kafka Wire Protocol values independently, without fetching the schema from Glue.

**Context:**
For my application, I am getting batches of Kafka records, and I currently have a `Promise.all` to analyze each message.

This is causing rate limits to be exceeded, due to the number of Glue SDK calls made.

Instead, this will allow me to fetch all of the Producer Schema Ids upfront and fetch them once, to use for a decoding function.